### PR TITLE
:bug: Remove matcher for AWS Secret Access Key due to false positives

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sanctify (0.2.5)
+    sanctify (0.2.4)
       git (~> 1.3)
 
 GEM
@@ -40,4 +40,4 @@ DEPENDENCIES
   sanctify!
 
 BUNDLED WITH
-   1.16.1
+   1.16.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sanctify (0.2.4)
+    sanctify (0.2.5)
       git (~> 1.3)
 
 GEM
@@ -40,4 +40,4 @@ DEPENDENCIES
   sanctify!
 
 BUNDLED WITH
-   1.16.0
+   1.16.1

--- a/lib/sanctify/cli.rb
+++ b/lib/sanctify/cli.rb
@@ -42,6 +42,7 @@ module Sanctify
         end
       end
       Scanner.new(args).run
+      puts "SUCCESS! No Secrets Found in #{args[:repo]}"
     end
   end
 end

--- a/lib/sanctify/matcher_list.rb
+++ b/lib/sanctify/matcher_list.rb
@@ -28,6 +28,10 @@ module Sanctify
         regex: /AKIA[0-9A-Z]{16}/
       },
       {
+        description: "AWS Secret Key",
+        regex: /\b(?<![A-Za-z0-9\/+=])(?=.*[\/&?=-@#$%\\^+])[A-Za-z0-9\/+=]{40}(?![A-Za-z0-9\/+=])\b/
+      },
+      {
         description: "SSH RSA Private Key",
         regex: /^-----BEGIN RSA PRIVATE KEY-----$/
       },

--- a/lib/sanctify/matcher_list.rb
+++ b/lib/sanctify/matcher_list.rb
@@ -28,10 +28,6 @@ module Sanctify
         regex: /AKIA[0-9A-Z]{16}/
       },
       {
-        description: "AWS Secret Key",
-        regex: /\b(?<![A-Za-z0-9\/+=])(?=.*[\/&?=-@#$%\\^+])[A-Za-z0-9\/+=]{40}(?![A-Za-z0-9\/+=])\b/
-      },
-      {
         description: "SSH RSA Private Key",
         regex: /^-----BEGIN RSA PRIVATE KEY-----$/
       },

--- a/lib/sanctify/matcher_list.rb
+++ b/lib/sanctify/matcher_list.rb
@@ -29,7 +29,7 @@ module Sanctify
       },
       {
         description: "AWS Secret Key",
-        regex: /\b(?<![A-Za-z0-9\/+=])(?=.*[\/&?=-@#$%\\^+])[A-Za-z0-9\/+=]{40}(?![A-Za-z0-9\/+=])\b/
+        regex: /\b(?<![A-Za-z0-9\/+=])(?=.*[&?=-@#$%\\^+])[A-Za-z0-9\/+=]{40}(?![A-Za-z0-9\/+=])\b/
       },
       {
         description: "SSH RSA Private Key",

--- a/lib/sanctify/scanner.rb
+++ b/lib/sanctify/scanner.rb
@@ -20,7 +20,6 @@ module Sanctify
           end
         end
       end
-      puts "SUCCESS! No Secrets Found in #{repo.path}"
     end
 
     private

--- a/spec/lib/cli_spec.rb
+++ b/spec/lib/cli_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe Sanctify::CLI, git: true do
   end
   context 'without config' do
     let(:argv) { ['-r', repo] }
-    it 'should not raise an error' do
-      expect{ subject }.not_to raise_error
+    it 'should raise an error' do
+      expect{ subject }.to raise_error(Sanctify::ScannerError)
     end
   end
   context 'with config' do
     let(:argv) { ['-r', repo, '-c', "spec/fixtures/sanctify.yml"] }
-    it 'should not raise an error' do
+    it 'should raise an error' do
       expect{ subject }.not_to raise_error
     end
   end

--- a/spec/lib/cli_spec.rb
+++ b/spec/lib/cli_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe Sanctify::CLI, git: true do
   end
   context 'without config' do
     let(:argv) { ['-r', repo] }
-    it 'should raise an error' do
-      expect{ subject }.to raise_error(Sanctify::ScannerError)
+    it 'should not raise an error' do
+      expect{ subject }.not_to raise_error
     end
   end
   context 'with config' do
     let(:argv) { ['-r', repo, '-c', "spec/fixtures/sanctify.yml"] }
-    it 'should raise an error' do
+    it 'should not raise an error' do
       expect{ subject }.not_to raise_error
     end
   end

--- a/spec/lib/scanner_spec.rb
+++ b/spec/lib/scanner_spec.rb
@@ -25,6 +25,27 @@ RSpec.describe Sanctify::Scanner, git: true do
       end
     end
 
+    context 'with AWS Secret Key that does not have a "/" character' do
+      let(:payload) { "pIW+g216XEHyoF+dIHkYgh439nGko8ga65VTusGF" }
+      it 'raises an error' do
+        expect{ subject }.to raise_error(Sanctify::ScannerError)
+      end
+    end
+
+    context 'with an innocent 40-character path using a base64 alphabet' do
+      let(:payload) { "yourlibrary/some/40/character/path/Thing" }
+      it 'does not raise an error' do
+        expect{ subject }.not_to raise_error
+      end
+    end
+
+    context 'with a 40-character string using a base64 alphabet' do
+      let(:payload) { "OKIKnowSomeClassNamesAreJustReallyLongOK" }
+      it 'does not raise an error' do
+        expect{ subject }.not_to raise_error
+      end
+    end
+
     context 'with git sha' do
       let(:payload) { "a74e98e6c224a9d2dba20c858009a4cb51689822" }
       it 'does not raise an error' do

--- a/spec/lib/scanner_spec.rb
+++ b/spec/lib/scanner_spec.rb
@@ -18,6 +18,13 @@ RSpec.describe Sanctify::Scanner, git: true do
       end
     end
 
+    context 'with AWS Secret Key' do
+      let(:payload) { "pIW/g216XEHyoF+dIHkYgh439nGko8ga65VTusGF" }
+      it 'raises an error' do
+        expect{ subject }.to raise_error(Sanctify::ScannerError)
+      end
+    end
+
     context 'with git sha' do
       let(:payload) { "a74e98e6c224a9d2dba20c858009a4cb51689822" }
       it 'does not raise an error' do
@@ -29,6 +36,13 @@ RSpec.describe Sanctify::Scanner, git: true do
       let(:payload) { "yyyyyy/tttt/ggggggggg/aaa_aaaa_aaaaaaaa/_bbbb_/cccc_dd_eeeee_vvvvvvv/bbbbb_iiiiiiii.yml" }
       it 'does not raise an error' do
         expect{ subject }.not_to raise_error
+      end
+    end
+
+    context 'with AWS Secret Key' do
+      let(:payload) { "pIW/g216XEHyoF+dIHkYgh439nGko8ga65VTusGF" }
+      it 'raises an error' do
+        expect{ subject }.to raise_error(Sanctify::ScannerError)
       end
     end
   end

--- a/spec/lib/scanner_spec.rb
+++ b/spec/lib/scanner_spec.rb
@@ -18,13 +18,6 @@ RSpec.describe Sanctify::Scanner, git: true do
       end
     end
 
-    context 'with AWS Secret Key' do
-      let(:payload) { "pIW/g216XEHyoF+dIHkYgh439nGko8ga65VTusGF" }
-      it 'raises an error' do
-        expect{ subject }.to raise_error(Sanctify::ScannerError)
-      end
-    end
-
     context 'with git sha' do
       let(:payload) { "a74e98e6c224a9d2dba20c858009a4cb51689822" }
       it 'does not raise an error' do
@@ -36,13 +29,6 @@ RSpec.describe Sanctify::Scanner, git: true do
       let(:payload) { "yyyyyy/tttt/ggggggggg/aaa_aaaa_aaaaaaaa/_bbbb_/cccc_dd_eeeee_vvvvvvv/bbbbb_iiiiiiii.yml" }
       it 'does not raise an error' do
         expect{ subject }.not_to raise_error
-      end
-    end
-
-    context 'with AWS Secret Key' do
-      let(:payload) { "pIW/g216XEHyoF+dIHkYgh439nGko8ga65VTusGF" }
-      it 'raises an error' do
-        expect{ subject }.to raise_error(Sanctify::ScannerError)
       end
     end
   end


### PR DESCRIPTION
Git commit hashes were matching the regular expression pattern for AWS Secret Access Keys.
Actually, any string of 40 characters would match the pattern.

For example:

> ```js
> import Widget from 'yourlibrary/some/40/character/path/Thing';
> ```

AWS Secret Access Keys are actually arbitrary base64-encoded 40-character strings.
Since hex is a subset of the base64 alphabet, a 40-character hex string (for example,
a git commit hash or any SHA1 sum) matches the pattern for a 40-character base64 string.
Unlike an AWS Access Key ID, which has a well-known prefix ("AKIA"), a secret access
key has no distinguishing trait other than this. It is safer, then, to remove the matcher
altogether (from the default list, anyway), than to risk false positives.