### PR TITLE
Ability for users to disable default matchers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sanctify (0.2.5)
+    sanctify (0.3.0)
       git (~> 1.3)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -48,14 +48,15 @@ repos:
 
 ## Configuration
 
-Sanctify supports two top-level objects in the config: `ignored_paths` and `custom_matchers`. Currently sanctify supports a number of default matchers, but you are free to add more to your config file under custom_matchers. If there is a file that you know has secrets or is a false positive, you can add a list of Ruby-style regexes to ignore certain files.
+Sanctify supports 3 top-level objects in the config: `ignored_paths`,`custom_matchers`, and `disabled_matchers`. Currently sanctify supports a number of default matchers, but you are free to add more to your config file under custom_matchers. If there is a file that you know has secrets or is a false positive, you can add a list of Ruby-style regexes to ignore certain files. Currently the `id` field is optional and is used to select matchers from the default list you want to disable. However, we recommend adding an `id` so that in future features you will be able to explicitly reference your custom matcher as well.
 
 Here's an example config file:
 
 ```yaml
 ---
 custom_matchers:
-  - description: "Test Description"
+  - id: test_description
+    description: "Test Description"
     regex: "secret.*"
 
 ignored_paths:
@@ -80,7 +81,7 @@ The list of current default matchers are located in  `lib/sanctify/matcher_list.
 ]
 ```
 
-If you'd like to disable certain matchers from the default list, you can do so my adding the id of the matcher you'd like to disable to a list in the config called `disabled_matchers`. The id of a matcher is simply the downcased description with spaces replaced with underscores. For example, if you wanted to disable all default matchers and only use your custom matchers, you can add the following to the config:
+If you'd like to disable certain matchers from the default list, you can do so by adding the `id` of the matcher you'd like to disable to a list in the config called `disabled_matchers`. For example, if you wanted to disable all default matchers and only use your custom matchers, you can add the following to the config:
 
 ```yaml
 disabled_matchers:

--- a/README.md
+++ b/README.md
@@ -80,7 +80,26 @@ The list of current default matchers are located in  `lib/sanctify/matcher_list.
 ]
 ```
 
+If you'd like to disable certain matchers from the default list, you can do so my adding the id of the matcher you'd like to disable to a list in the config called `disabled_matchers`. The id of a matcher is simply the downcased description with spaces replaced with underscores. For example, if you wanted to disable all default matchers and only use your custom matchers, you can add the following to the config:
+
+```yaml
+disabled_matchers:
+  - aws_access_key_id
+  - aws_secret_key
+  - ssh_rsa_private_key
+  - x509_certificate
+  - redis_url_with_password
+  - url_basic_auth
+  - google_access_token
+  - google_api
+  - slack_api
+  - slack_bot
+  - gem_fury_v1
+  - gem_fury_v2
+```
+
 If you see any problem with a default matcher list or would like to add another to the default list, please feel free to make a pull request.
+
 
 ## Troubleshooting
 

--- a/lib/sanctify/matcher.rb
+++ b/lib/sanctify/matcher.rb
@@ -1,0 +1,27 @@
+module Sanctify
+  class Matcher
+    attr_reader :description, :regex, :config
+    def initialize(description, regex, config)
+      @description = description
+      @regex = regex
+      @config = config
+    end
+
+    def id
+      description.downcase.gsub(' ', '_')
+    end
+
+    def disabled?
+      # NOTE: Allow users to specify entire description or something like it.
+      # For example, this would allow a user to disable matchers with description:
+      #
+      disabled_matchers = config['disabled_matchers'] || []
+      disabled_matchers.each do |dis|
+        if dis == id
+          return true
+        end
+      end
+      return false
+    end
+  end
+end

--- a/lib/sanctify/matcher.rb
+++ b/lib/sanctify/matcher.rb
@@ -1,27 +1,15 @@
 module Sanctify
   class Matcher
-    attr_reader :description, :regex, :config
-    def initialize(description, regex, config)
+    attr_reader :id, :description, :regex
+    def initialize(id, description, regex, disabled: false)
+      @id = id
       @description = description
       @regex = regex
-      @config = config
-    end
-
-    def id
-      description.downcase.gsub(' ', '_')
+      @disabled = disabled
     end
 
     def disabled?
-      # NOTE: Allow users to specify entire description or something like it.
-      # For example, this would allow a user to disable matchers with description:
-      #
-      disabled_matchers = config['disabled_matchers'] || []
-      disabled_matchers.each do |dis|
-        if dis == id
-          return true
-        end
-      end
-      return false
+      @disabled
     end
   end
 end

--- a/lib/sanctify/matcher_list.rb
+++ b/lib/sanctify/matcher_list.rb
@@ -3,15 +3,21 @@ require 'sanctify/matcher'
 module Sanctify
   class ParserError < StandardError; end
   class MatcherList
-    attr_reader :config
-    def initialize(config)
-      @matchers = DEFAULT_MATCHERS.map{ |obj| Matcher.new(obj[:description], obj[:regex], config) }
-      @config = config
+    def initialize(custom_matchers:, disabled_matchers:)
+      # initialize Array in case users have that field blank
+      @disabled_matchers = disabled_matchers || []
+      @custom_matchers = custom_matchers || []
+
+      # Create Matcher objects out of const.
+      @matchers = DEFAULT_MATCHERS.map do |obj|
+        disabled = @disabled_matchers.include?(obj[:id])
+        Matcher.new(obj[:id], obj[:description], obj[:regex], disabled: disabled)
+      end
       initialize_custom_matchers!
     end
 
-    def add(description, regex)
-      if description.length.zero?
+    def add(id, description, regex)
+      if description.empty?
         raise ParserError, "Description must exist and be greater length than zero"
       end
 
@@ -19,8 +25,7 @@ module Sanctify
         raise ParserError, "Regex must be of type Regexp"
       end
 
-      @matchers << Matcher.new(description, regex, config)
-      @matchers
+      @matchers << Matcher.new(id, description, regex)
     end
 
     def each(&blk)
@@ -28,11 +33,10 @@ module Sanctify
     end
 
     def initialize_custom_matchers!
-      custom_matchers = config['custom_matchers'] || []
-      if custom_matchers.any?
-        custom_matchers.each do |cust|
+      if @custom_matchers.any?
+        @custom_matchers.each do |cust|
           if cust['description'] && cust['regex']
-            add(cust['description'], Regexp.new(cust['regex']))
+            add(cust['id'], cust['description'], Regexp.new(cust['regex']))
           else
             raise ParserError, "Improperly configured custom matcher: #{cust}. Must include 'description' and 'regex'"
           end
@@ -42,10 +46,12 @@ module Sanctify
 
     DEFAULT_MATCHERS = [
       {
+        id: "aws_access_key_id",
         description: "AWS Access Key ID",
         regex: /AKIA[0-9A-Z]{16}/
       },
       {
+        id: "aws_secret_key",
         description: "AWS Secret Key",
         # NOTE: This regex does not match keys that include a /, which is allowed
         # in base64. If we added the slash, there would be many false positives
@@ -54,42 +60,52 @@ module Sanctify
         regex: /\b(?<![A-Za-z0-9\/+=])(?=.*[&?=-@#$%\\^+])[A-Za-z0-9\/+=]{40}(?![A-Za-z0-9\/+=])\b/
       },
       {
+        id: "ssh_rsa_private_key",
         description: "SSH RSA Private Key",
         regex: /^-----BEGIN RSA PRIVATE KEY-----$/
       },
       {
-        description: "X509 Certificate",
+        id: "x509_certificate",
+        description: "X.509 Certificate",
         regex: /^-----BEGIN CERTIFICATE-----$/
       },
       {
+        id: "redis_url_with_password",
         description: "Redis URL with Password",
         regex: /redis:\/\/[0-9a-zA-Z:@.\\-]+/
       },
       {
+        id: "url_basic_auth",
         description: "URL Basic auth",
         regex: /https?:\/\/[0-9a-zA-z_]+?:[0-9a-zA-z_]+?@.+?/
       },
       {
+        id: "google_access_token",
         description:"Google Access Token",
         regex: /ya29.[0-9a-zA-Z_\\-]{68}/
       },
       {
+        id: "google_api",
         description: "Google API",
         regex: /AIzaSy[0-9a-zA-Z_\\-]{33}/
       },
       {
+        id: "slack_api",
         description: "Slack API",
         regex: /xoxp-\\d+-\\d+-\\d+-[0-9a-f]+/
       },
       {
+        id: "slack_bot",
         description: "Slack Bot",
         regex: /xoxb-\\d+-[0-9a-zA-Z]+/
       },
       {
+        id: "gem_fury_v1",
         description: "Gem Fury v1",
         regex: /https?:\/\/[0-9a-zA-Z]+@[a-z]+\\.(gemfury.com|fury.io)(\/[a-z]+)?/
       },
       {
+        id: "gem_fury_v2",
         description: "Gem Fury v2",
         regex: /https?:\/\/[a-z]+\\.(gemfury.com|fury.io)\/[0-9a-zA-Z]{20}/
       }

--- a/lib/sanctify/repo.rb
+++ b/lib/sanctify/repo.rb
@@ -2,13 +2,13 @@ require 'git'
 
 module Sanctify
   class Repo
-    attr_reader :path, :git, :ignored_paths
-    def initialize(args, ignored_paths = [])
+    attr_reader :path, :git, :config
+    def initialize(args, config = {})
       @path = args[:repo]
       @to = args[:to] # The default for `to` in git.diff is nil
       @from = args[:from] || 'HEAD'
       @git = Git.open(path)
-      @ignored_paths = ignored_paths
+      @config = config
     end
 
     def diff
@@ -45,6 +45,11 @@ module Sanctify
 
     def added_line?(line)
       line.start_with?('+') && !line.start_with?('+++')
+    end
+
+    def ignored_paths
+      patterns = config['ignored_paths'] || []
+      patterns.map { |patt| Regexp.new patt }
     end
   end
 end

--- a/lib/sanctify/scanner.rb
+++ b/lib/sanctify/scanner.rb
@@ -7,36 +7,16 @@ module Sanctify
     attr_reader :config, :repo, :matcher_list
     def initialize(args)
       @config = args[:config] || {}
-      @repo = Repo.new(args, ignored_paths)
-      @matcher_list = MatcherList.new
+      @repo = Repo.new(args, config)
+      @matcher_list = MatcherList.new(config)
     end
 
     def run
-      initialize_custom_matchers!
       repo.added_lines.each do |line, path|
         matcher_list.each do |matcher|
-          if matcher[:regex].match(line)
-            raise ScannerError, "[ERROR] SECRET FOUND (#{matcher[:description]}): #{line} : #{path}"
-          end
-        end
-      end
-    end
-
-    private
-
-    def ignored_paths
-      patterns = config['ignored_paths'] || []
-      patterns.map { |patt| Regexp.new patt }
-    end
-
-    def initialize_custom_matchers!
-      custom_matchers = config['custom_matchers'] || []
-      if custom_matchers.any?
-        custom_matchers.each do |cust|
-          if cust['description'] && cust['regex']
-            matcher_list.add(desc: cust['description'], regex: Regexp.new(cust['regex']))
-          else
-            raise ScannerError, "Improperly configured custom matcher: #{cust}. Must include 'description' and 'regex'"
+          next if matcher.disabled?
+          if matcher.regex.match(line)
+            raise ScannerError, "[ERROR] SECRET FOUND (#{matcher.description}): #{line} : #{path}"
           end
         end
       end

--- a/lib/sanctify/version.rb
+++ b/lib/sanctify/version.rb
@@ -1,3 +1,3 @@
 module Sanctify
-  VERSION = "0.2.5"
+  VERSION = "0.3.0"
 end

--- a/spec/fixtures/sanctify.yml
+++ b/spec/fixtures/sanctify.yml
@@ -6,3 +6,5 @@ custom_matchers:
 ignored_paths:
   - test.*
   - thing.rb
+disabled_matchers:
+  - aws_secret_key

--- a/spec/lib/scanner_spec.rb
+++ b/spec/lib/scanner_spec.rb
@@ -71,10 +71,12 @@ RSpec.describe Sanctify::Scanner, git: true do
   context 'with config' do
     let(:ignored_paths) { [] }
     let(:custom_matchers) { [] }
+    let(:disabled_matchers){ [] }
     let(:config) do
       {
         'ignored_paths' => ignored_paths,
-        'custom_matchers' => custom_matchers
+        'custom_matchers' => custom_matchers,
+        'disabled_matchers' => disabled_matchers
       }
     end
     subject { Sanctify::Scanner.new({repo: @path, config: config}).run }
@@ -97,6 +99,14 @@ RSpec.describe Sanctify::Scanner, git: true do
         it 'raises an error' do
           expect{ subject }.to raise_error(Sanctify::ScannerError)
         end
+      end
+    end
+
+    context 'with disabled_matchers' do
+      let(:disabled_matchers) { ['aws_secret_key'] }
+      let(:payload) { "pIW/g216XEHyoF+dIHkYgh439nGko8ga65VTusGF" }
+      it 'does not raise an error' do
+        expect { subject }.not_to raise_error
       end
     end
   end


### PR DESCRIPTION
- Added config option to list matchers a users wants to disable
- Created Matcher class with `id` method
- Pass `config` from Scanner entry point down to instantiated classed for better single responsibility.